### PR TITLE
Update the spacing scale to reflect the latest Tailwind version

### DIFF
--- a/src/lookup.js
+++ b/src/lookup.js
@@ -1,5 +1,5 @@
 export default async function lookup(arg) {
-  const spacing = [1, 2, 3, 4, 5, 6, 8, 10, 12, 16, 20, 24, 32, 40, 48, 56, 64];
+  const spacing = [0, 0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60, 64, 72, 80, 96];
   let goal = arg / 4;
 
   let output = spacing.reduce((prev, curr) =>


### PR DESCRIPTION
Update the spacing scale in `src/lookup.js` to reflect the latest Tailwind version.

* Update the `spacing` array to include the latest Tailwind spacing values: [0, 0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60, 64, 72, 80, 96].

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/JPrisk/tailwind-spacing-cli?shareId=2dc3ee0a-31ce-46d8-8364-581db383ba87).